### PR TITLE
add #{tmux_mode_style} placeholder for duplicating mode indicator color

### DIFF
--- a/mode_indicator.tmux
+++ b/mode_indicator.tmux
@@ -3,6 +3,7 @@
 set -e
 
 declare -r mode_indicator_placeholder="\#{tmux_mode_indicator}"
+declare -r mode_style_placeholder="\#{tmux_mode_style}"
 
 declare -r prefix_prompt_config='@mode_indicator_prefix_prompt'
 declare -r copy_prompt_config='@mode_indicator_copy_prompt'
@@ -47,10 +48,14 @@ init_tmux_mode_indicator() {
 
   local -r mode_indicator="#[default]$mode_style$mode_prompt#[default]"
 
-  local -r status_left_value="$(tmux_option "status-left")"
-  tmux set-option -gq "status-left" "${status_left_value/$mode_indicator_placeholder/$mode_indicator}"
+  local status_left_value="$(tmux_option "status-left")"
+  status_left_value="${status_left_value/$mode_indicator_placeholder/$mode_indicator}"
+  status_left_value="${status_left_value/$mode_style_placeholder/$mode_style}"
+  tmux set-option -gq "status-left" "$status_left_value"
 
-  local -r status_right_value="$(tmux_option "status-right")"
+  local status_right_value="$(tmux_option "status-right")"
+  status_right_value="${status_right_value/$mode_indicator_placeholder/$mode_indicator}"
+  status_right_value="${status_right_value/$mode_style_placeholder/$mode_style}"
   tmux set-option -gq "status-right" "${status_right_value/$mode_indicator_placeholder/$mode_indicator}"
 }
 


### PR DESCRIPTION
Hi,

I wanted for myself to have an additional placeholder for the style of the mode indicator, so I could duplicate it somewhere else in the status bar (e.g. have both far end of the status line change color, similar to vim-airlines).
So that you could easily do something like that:

![Screenshot from 2024-03-25 10-42-59](https://github.com/MunifTanjim/tmux-mode-indicator/assets/45769625/a3d65f22-40ff-4e58-ad66-cd4e55cf8f0f)
![Screenshot from 2024-03-25 10-42-49](https://github.com/MunifTanjim/tmux-mode-indicator/assets/45769625/a2c148c5-df2a-4076-93d7-90fa96ec95fe)

Feel free to take it in as well if you're interested :)

Have a good day !